### PR TITLE
Fixed rubocop and foodcritic and added necessary files

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,7 +1,4 @@
 ---
-provisioner:
-  name: chef_solo
-
 suites:
   - name: default
     run_list:

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--format documentation --color

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,18 @@ AllCops:
     - '**/Cheffile'
   Exclude:
     - 'metadata.rb'
+
+Style/NumericLiteralPrefix:
+  EnforcedOctalStyle: zero_only
+
+Metrics/LineLength:
+  Max: 120
+
+Style/IfUnlessModifier:
+  MaxLineLength: 120
+
+Style/WhileUntilModifier:
+  MaxLineLength: 120
+
+Metrics/BlockLength:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+osl-varnish CHANGELOG
+=====================
+This file is used to list changes made in each version of the
+osl-varnish cookbook.
+
+0.1.0
+-----
+- Initial release of osl-varnish
+

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,130 @@
+# Rake tasks
+
+require 'rake'
+
+require 'fileutils'
+require 'base64'
+require 'chef/encrypted_data_bag_item'
+require 'json'
+require 'openssl'
+
+snakeoil_file_path = 'test/integration/data_bags/certificates/snakeoil.json'
+encrypted_data_bag_secret_path = 'test/integration/encrypted_data_bag_secret'
+
+##
+# Run command wrapper
+def run_command(command)
+  if File.exist?('Gemfile.lock')
+    sh %(bundle exec #{command})
+  else
+    sh %(chef exec #{command})
+  end
+end
+
+##
+# Create a self-signed SSL certificate
+#
+def gen_ssl_cert
+  name = OpenSSL::X509::Name.new [
+    ['C', 'US'],
+    ['ST', 'Oregon'],
+    ['CN', 'OSU Open Source Lab'],
+    ['DC', 'example']
+  ]
+  key = OpenSSL::PKey::RSA.new 2048
+
+  cert = OpenSSL::X509::Certificate.new
+  cert.version = 2
+  cert.serial = 2
+  cert.subject = name
+  cert.public_key = key.public_key
+  cert.not_before = Time.now
+  cert.not_after = cert.not_before + 1 * 365 * 24 * 60 * 60 # 1 years validity
+
+  # Self-sign the Certificate
+  cert.issuer = name
+  cert.sign(key, OpenSSL::Digest::SHA1.new)
+
+  return cert, key
+end
+
+##
+# Create a data bag item (with the id of snakeoil) containing a self-signed SSL
+#  certificate
+#
+def ssl_data_bag_item
+  cert, key = gen_ssl_cert
+  Chef::DataBagItem.from_hash(
+    'id' => 'snakeoil',
+    'cert' => cert.to_pem,
+    'key' => key.to_pem
+  )
+end
+
+##
+# Create the integration tests directory if it doesn't exist
+#
+directory 'test/integration'
+
+##
+# Generates a 512 byte random sequence and write it to
+#  'test/integration/encrypted_data_bag_secret'
+#
+file encrypted_data_bag_secret_path => 'test/integration' do
+  encrypted_data_bag_secret = OpenSSL::Random.random_bytes(512)
+  open encrypted_data_bag_secret_path, 'w' do |io|
+    io.write Base64.encode64(encrypted_data_bag_secret)
+  end
+end
+
+##
+# Create the certificates data bag if it doesn't exist
+#
+directory 'test/integration/data_bags/certificates' => 'test/integration'
+
+##
+# Create the encrypted snakeoil certificate under
+#  test/integration/data_bags/certificates
+#
+file snakeoil_file_path => [
+  'test/integration/data_bags/certificates',
+  'test/integration/encrypted_data_bag_secret'
+] do
+
+  encrypted_data_bag_secret = Chef::EncryptedDataBagItem.load_secret(
+    encrypted_data_bag_secret_path
+  )
+
+  encrypted_snakeoil_cert = Chef::EncryptedDataBagItem.encrypt_data_bag_item(
+    ssl_data_bag_item, encrypted_data_bag_secret
+  )
+
+  open snakeoil_file_path, 'w' do |io|
+    io.write JSON.pretty_generate(encrypted_snakeoil_cert)
+  end
+end
+
+desc 'Create an Encrypted Databag Snakeoil SSL Certificate'
+task snakeoil: snakeoil_file_path
+
+desc 'Create an Encrypted Databag Secret'
+task secret_file: encrypted_data_bag_secret_path
+
+require 'rubocop/rake_task'
+desc 'Run RuboCop (style) tests'
+RuboCop::RakeTask.new(:style)
+
+desc 'Run FoodCritic (lint) tests'
+task :lint do
+    run_command('foodcritic --epic-fail any .')
+end
+
+desc 'Run RSpec (unit) tests'
+task :unit do
+    run_command('rspec')
+end
+
+desc 'Run all tests'
+task test: [:style, :lint, :unit]
+
+task default: :test

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,6 +2,8 @@ name             'osl-varnish'
 maintainer       'Oregon State University'
 maintainer_email 'systems@osuosl.org'
 license          'Apache 2.0'
+issues_url       'https://github.com/osuosl-cookbooks/osl-varnish/issues'
+source_url       'https://github.com/osuosl-cookbooks/osl-varnish'
 description      'OSL wrapper cookbook for varnish'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.0.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -34,8 +34,7 @@ end
 # Enable varnishncsa instead.
 service 'varnishncsa' do
   supports status: true, restart: true
-  action node['osl-varnish']['ncsa_daemon'] ? %w(enable start) : \
-    %w(disable stop)
+  action node['osl-varnish']['ncsa_daemon'] ? %w(enable start) : %w(disable stop)
 end
 
 include_recipe 'firewall::varnishadm'

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,0 +1,14 @@
+require_relative 'spec_helper'
+
+describe 'osl-varnish::default' do
+  ALL_PLATFORMS.each do |p|
+    context "#{p[:platform]} #{p[:version]}" do
+      cached(:chef_run) do
+        ChefSpec::SoloRunner.new(p).converge(described_recipe)
+      end
+      it 'converges successfully' do
+        expect { chef_run }.to_not raise_error
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,15 +13,9 @@ CENTOS_6 = {
   version: '6.7'
 }.freeze
 
-DEBIAN_8 = {
-  platform: 'debian',
-  version: '8.4'
-}.freeze
-
 ALL_PLATFORMS = [
   CENTOS_6,
-  CENTOS_7,
-  DEBIAN_8
+  CENTOS_7
 ].freeze
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,29 @@
+require 'chefspec'
+require 'chefspec/berkshelf'
+
+ChefSpec::Coverage.start! { add_filter 'osl-varnish' }
+
+CENTOS_7 = {
+  platform: 'centos',
+  version: '7.2.1511'
+}.freeze
+
+CENTOS_6 = {
+  platform: 'centos',
+  version: '6.7'
+}.freeze
+
+DEBIAN_8 = {
+  platform: 'debian',
+  version: '8.4'
+}.freeze
+
+ALL_PLATFORMS = [
+  CENTOS_6,
+  CENTOS_7,
+  DEBIAN_8
+].freeze
+
+RSpec.configure do |config|
+  config.log_level = :fatal
+end


### PR DESCRIPTION
Chefspec tests need to be added to osl-varnish. In order to pass rake, this cookbook has to pass rubocop and foodcritic before even getting to chefspec. This PR fixes rubocop and foodcritic errors. I also used chef generate in order to add necessary files, such as .kitchen.yml and the Rakefile.